### PR TITLE
Update to handle UID and DX10His Screen

### DIFF
--- a/uScript/DX10.usc
+++ b/uScript/DX10.usc
@@ -19,13 +19,15 @@ start DX10(parmfile,option,client,retcode)
  %define col_color_multi "bgcolor='LightGrey'"  
  %global client,retcode
  %global SHOWLEGAX,10DOTTED,9DOTTED,CONVLEGC,PULLABLFW,SHOWABL
- %global UniqID,ICD_Code,ICD_Code_DotNt,ICD_Description,ICD_Code2,ICD_Code_DotNt2,ICD_Description2,DSM_4_Axis,Approximate,NoMap,Combination,Scenario,ChoiceList,DX_Cat,TermSearch,EffDt,EndDt
+ %global UniqID,ICD_Code,ICD_Code_DotNt,ICD_Description,ICD_Code2,ICD_Code_DotNt2,ICD_Description2,DSM_4_Axis,Approximate,NoMap
+ %global Combination,Scenario,ChoiceList,DX_Cat,TermSearch,EffDt,EndDt
  %global Selection,index ,lookup_btn,up_btn,down_btn,delete_btn
  %global c_dx10_icd10,c_dx10_icd10_des,c_dx10_icd9,c_dx10_icd9_des, c_dx10_legax,c_dx10_dxcat
  %global c_dx10_dxrank,next_index,prev_index,curr_index,axis1_10_dx,axis2_10_dx,c_dx10_uniq
  %global axis3_10_dx,axis1_10_desc,axis2_10_desc,axis3_10_desc,comp_axis1_10_dx
  %global comp_axis2_10_dx,comp_axis3_10_dx,comp_axis1_10_ds,comp_axis2_10_ds,comp_axis3_10_ds
- %global c_dx10_a4_supgrp,c_dx10_a4_socenv,c_dx10_a4_edu,c_dx10_a4_occ,c_dx10_a4_housng,c_dx10_a4_eco,c_dx10_a4_health,c_dx10_a4_legal,c_dx10_a4_psyenv,c_dx10_a4_none,c_dx10_a5_gaf,c_dx10_curr_abl,c_dx10_pot_abl,c_dx10_pimary_ax
+ %global c_dx10_a4_supgrp,c_dx10_a4_socenv,c_dx10_a4_edu,c_dx10_a4_occ,c_dx10_a4_housng,c_dx10_a4_eco,c_dx10_a4_health,c_dx10_a4_legal
+ %global c_dx10_a4_psyenv,c_dx10_a4_none,c_dx10_a5_gaf,c_dx10_curr_abl,c_dx10_pot_abl,c_dx10_pimary_ax
  %global c_dx10_dt,c_dx10_reason,c_dx10_a5_pgaf,c_dx10_comment,c_dx10_stat
  %global c_dx10_iq_score, c_dx10_iq_date, c_dx10_iq_test, c_dx10_sq_score, c_dx10_sq_date, c_dx10_sq_test
  %global errors, RequireABL
@@ -171,14 +173,18 @@ start DX10(parmfile,option,client,retcode)
  allow_discharge     is x
  %global allow_discharge
  
+ UIDpassed		 is x 				'ER001
+ UIDid			 is uid				'ER001
+ %global UIDpassed,UIDid			'ER001
+ 
  if parmfile !dp
   parmfile = "DX10"
  endif
 
  Page = "OnLoad"
  if $regid !dp
-  if client dp
-   $regid = client
+   if client dp
+    $regid = client
   else
    $regid = {"lib_txaceUI"}GetClientID()
    if $regid !dp
@@ -229,8 +235,9 @@ start DX10(parmfile,option,client,retcode)
                         elseif $maxarray(delete_btn[]) > 0
 			             curr_index = $maxarray(delete_btn[])  
 			             prev_index = curr_index - 1
-						 (void)$arrremove(c_dx10_dxrank[curr_index],1,c_dx10_uniq[],c_dx10_legax[],c_dx10_icd10[],c_dx10_icd9[],c_dx10_dxcat[],c_dx10_icd10_des[],c_dx10_icd9_des[],axis1_10_dx[],axis1_10_desc[],
-						 axis2_10_dx[],axis2_10_desc[],axis3_10_dx[],axis3_10_desc[],selection[])
+						 (void)$arrremove(c_dx10_dxrank[curr_index],1,c_dx10_uniq[],c_dx10_legax[],c_dx10_icd10[],c_dx10_icd9[],c_dx10_dxcat[],
+						 c_dx10_icd10_des[],c_dx10_icd9_des[],axis1_10_dx[],axis1_10_desc[],axis2_10_dx[],axis2_10_desc[],axis3_10_dx[],
+						 axis3_10_desc[],selection[])
 			             index = prev_index
 			             do while index++ < $maxarray(c_dx10_legax[])
 			              c_dx10_dxrank[index] = c_dx10_dxrank[index] - 1
@@ -341,6 +348,10 @@ function Onload(parmfile, option) is x
  dx_dst = $uc(dx_dst)
  $setvarname(creds_dst, creds_dst)
  $setvarname(dx_dst, dx_dst)
+ 
+ if UIDpassed dp						'ER001
+	UIDid = UIDpassed					'ER001
+ endif 									'ER001
 '****************************
 'do the security(void)
  (void)$getopergroups($oper, groupmembership[], groupaccess[])
@@ -411,12 +422,26 @@ function Onload(parmfile, option) is x
  {"lib_DX10"}Set_Sql(o_user, o_pass, o_ds, o_db, icd10_table, icd9_table)
 
  rc = $dbread(2,$regid,c.fn,c.mn,c.ln,c.bd)
- rc = $dbread(2,$regid,dx10_dstlist)
- c_dx10_a5_pgaf = {"lib_DX10"}PreviousGAF(icd9_gaf_dst)
+ 'rc = $dbread(2,$regid,dx10_dstlist)			ER001
+ 
+'ER001 ---------- 
+ 
+	if UIDid dp 	'if UID has been passed in - find that record
+		rc = $dbreaduid(UIDid,2,$regid,dx10_dstlist)
+	else			'Otherwise we just get the most recent diagnosis
+		rc = $dbread(2,$regid,dx10_dstlist)
+	endif
+	
+'ER001 ----------  
+ if OnLoad <> "VIEW"	'ER001		
+ 	c_dx10_a5_pgaf = {"lib_DX10"}PreviousGAF(icd9_gaf_dst) 	
+ endif
  if c.dx10.dt dp and c.dx10.converted != "Y"
-  If PromptPullFW(PULLFW, ForcePullFw) = "Y" 
+  If PromptPullFW(PULLFW, ForcePullFw) = "Y"	'If user or program selected Y - load all the work fields	ER001 
    index = 1
-   $clear(c.dx10.dt)
+   	if UIDid !dp		'For view/update diagnosis - leave date 	ER001
+   		$clear(c.dx10.dt)	
+	endif				'ER001
    c_dx10_dxrank[index]    = c.dx10.dxrank.1
    c_dx10_uniq[index]      = c.dx10.uniq.1 
    c_dx10_dxrank[++index]  = c.dx10.dxrank.2
@@ -460,7 +485,13 @@ function Onload(parmfile, option) is x
    c_dx10_a4_legal         = c.dx10.a4.legal 
    c_dx10_a4_psyenv        = c.dx10.a4.psyenv
    c_dx10_a4_none          = c.dx10.a4.none  
- '  c_dx10_a5_gaf           = c.dx10.a5.gaf   
+if UIDid dp 	'If working with existing diagnosis - load these specific display fields 	ER001
+	c_dx10_a5_gaf           = c.dx10.a5.gaf   
+	c_dx10_dt				= c.dx10.dt
+	c_dx10_reason			= c.dx10.reason	
+	c_dx10_staff			= c.dx10.staff
+	c_dx10_comment			= c.dx10.comment
+endif			'ER001
    c_dx10_curr_abl         = c.dx10.curr.abl 
    c_dx10_pot_abl          = c.dx10.pot.abl
    c_dx10_iq_score         = c.dx10.iq.score
@@ -510,7 +541,7 @@ function Onload(parmfile, option) is x
     c_dx10_icd10[index] = ICD_Code
     c_dx10_icd9[index]  = ICD_Code2
     c_dx10_dxcat[index] = DX_Cat
-   enddo 
+	 enddo 
    ResortDXRecord()
   else
    $clear(c.dx10.rh,c.dx10.staff,c.dx10.entstaff,c.dx10.dt,c.dx10.time,c.dx10.entdt,c.dx10.enttm,c.dx10.caredt,c.dx10.reason,c.dx10.expire,c.dx10.pimary.ax,
@@ -537,7 +568,7 @@ function Onload(parmfile, option) is x
   c.dx10.icd10.13,c.dx10.icd9.13,c.dx10.legax.13,c.dx10.dxcat.13,c.dx10.dxrank.13,c.dx10.uniq.13,c.dx10.icd10.14,c.dx10.icd9.14,c.dx10.legax.14,c.dx10.dxcat.14,c.dx10.dxrank.14,c.dx10.uniq.14,
   c.dx10.icd10.15,c.dx10.icd9.15,c.dx10.legax.15,c.dx10.dxcat.15,c.dx10.dxrank.15,c.dx10.uniq.15,c.dx10.icd10.16,c.dx10.icd9.16,c.dx10.legax.16,c.dx10.dxcat.16,c.dx10.dxrank.16,c.dx10.uniq.16,
   c.dx10.a4.supgrp,c.dx10.a4.socenv,c.dx10.a4.edu,c.dx10.a4.occ,c.dx10.a4.housng,c.dx10.a4.eco,c.dx10.a4.health,c.dx10.a4.legal,c.dx10.a4.psyenv,c.dx10.a4.none,c.dx10.a5.gaf,c.dx10.curr.abl,c.dx10.pot.abl,
-   c.dx10.iq.score, c.dx10.iq.date, c.dx10.iq.test, c.dx10.sq.score, c.dx10.sq.date, c.dx10.sq.test,
+  c.dx10.iq.score, c.dx10.iq.date, c.dx10.iq.test, c.dx10.sq.score, c.dx10.sq.date, c.dx10.sq.test,
   c.dx10.comment,c.dx10.snapid,c.dx10.isn,c.dx10.stat)
  endif 
 end OnLoad 
@@ -610,7 +641,11 @@ function Page1() is null
  $cancelopt("off","Cancel")
  $form($funcname)
  $br(){"lib_txaceUI"}ClientPageHeader($regid)
-  $br()$text("{center}ICD-10 Diagnosis Entry{/center}","H1")  
+ if UIDid !dp		'ER001 - no UID passed so this is entry
+  	$br()$text("{center}ICD-10 Diagnosis Entry{/center}","H1")
+  else				'ER001 - We got a UID so this is an update
+  	$br()$text("{center}ICD-10 Diagnosis Update{/center}","H1")
+  endif				'ER001  
   $br()
   $table($funcname,,table_nobgcolor)
    $row()
@@ -627,7 +662,6 @@ function Page1() is null
   if mode = "DATAENTRY"
    $br(2)$text("Diagnosis Staff: ","datatag")$textbox(c_dx10_staff ,"DB``03",6,,"Y")$editmsg(c_dx10_staff )
   endif  
-
   $br(2)
   $fieldset("Diagnosis Codes",,"datatag")
    $br()$submit(lookup_btn,"Lookup")
@@ -900,6 +934,12 @@ function Page2() is null
   $br(2)$text("{center}ICD-10 Diagnosis Record{/center}","H1")
   $br()
   $table($funcname,,table_nobgcolor)
+  reasondesc is x
+  select c_dx10_reason
+  	case "1"	reasondesc = "Admitting"
+	case "2"	reasondesc = "Interim"
+	case "3"	reasondesc = "Death"
+	endselect
    $row()
     $col("center")$text("Diagnosis Date: ")$text(c_dx10_dt)
     $col("center")$text("Reason: ")
@@ -914,6 +954,7 @@ function Page2() is null
       case "C"   $text("Confirmed")
       case "P"   $text("Provisional")
     endselect
+
    if c.bd dp
     $row()
      $col("center")$text("Birth Date:")$text(c.bd)
@@ -1141,9 +1182,12 @@ function Validate1() is i
  if c_dx10_dt > $today
   (void)$arrpush(errors[],"The Diagnosis Date cannot be future dated")
  endif
- if last_date dp and last_date > c_dx10_dt
-  (void)$arrpush(errors[],`"Diagnosis Date cannot be older than the current diagnosis record dated {u}{b}" + $castx(last_date) + "{/b}{/u}"`)  
- endif
+ 
+ if UIDid !dp	'Only check for prior dating if we're creating a new record, not updating and existing one	ER001
+ 	if last_date dp and last_date > c_dx10_dt
+ 	 (void)$arrpush(errors[],`"Diagnosis Date cannot be older than the current diagnosis record dated {u}{b}" + $castx(last_date) + "{/b}{/u}"`)  
+ 	endif
+ endif			'ER001
 
 'R-01-06
  if c_dx10_dt < c.bd
@@ -1378,7 +1422,7 @@ function SaveData() is i
  c.dx10.rh[effd] = c_dx10_dt
  NewUID = c.dx10.rh[uid] 
  c.dx10.entstaff = $operstaffid
- if mode = "DATAENTRY"
+ if mode = "DATAENTRY" or UIDid dp			'ER001 - if updating a diagnosis, the diagnosing staff shouldnt change
   c.dx10.staff = c_dx10_staff 
  else
   c.dx10.staff = $operstaffid 
@@ -1727,10 +1771,26 @@ function SaveData() is i
    c.dx10.uniq.16   = UniqID
   endif  
 
-  if dosave = "Y"
-   $dblock()
-   SaveData = $dbpoint(2,$regid,c.dx10.rh)
-   SaveData = $dbadddst(2,$regid,dx10_dstlist) 
+  if dosave = "Y"		'ER001 - Here we go, using the functions instead of the dbadddst   
+   '$dblock()
+   'SaveData = $dbpoint(2,$regid,c.dx10.rh)
+   'SaveData = $dbadddst(2,$regid,dx10_dstlist) 
+   
+   if UIDid dp		'ER001 - Because the user is updating the diagnosis - this function creates a new record, then voids the old one
+   
+   {"lib_DX10"}updateClientDx(UIDid, $regid, c.dx10.dt, c.dx10.staff, c.dx10.dt, c.dx10.time, c.dx10.entdt, c.dx10.enttm, c.dx10.expire, c.dx10.reason, 
+   c.dx10.stat, c.dx10.pimary.ax,c_dx10_uniq[],c.dx10.comment,10dotted, 9dotted,c.dx10.a4.supgrp, c.dx10.a4.socenv, c.dx10.a4.edu, c.dx10.a4.occ, 
+   c.dx10.a4.housng, c.dx10.a4.eco, c.dx10.a4.health, c.dx10.a4.legal, c.dx10.a4.psyenv, c.dx10.a4.none, c.dx10.a5.gaf, c.dx10.curr.abl, 
+   c.dx10.pot.abl,c.dx10.iq.score,c.dx10.iq.date,c.dx10.iq.test,c.dx10.sq.score,c.dx10.sq.date,c.dx10.sq.test, c.dx10.snapid, c.dx10.converted)
+    
+   else				'Write a new diagnosis record
+   
+   {"lib_DX10"}putClientDx(UIDid, $regid, $today, c.dx10.staff, c.dx10.dt, c.dx10.time, c.dx10.entdt, c.dx10.enttm, c.dx10.expire, c.dx10.reason, 
+   c.dx10.stat,c.dx10.pimary.ax, c_dx10_uniq[], c.dx10.comment, 10dotted, 9dotted, c.dx10.a4.supgrp, c.dx10.a4.socenv, c.dx10.a4.edu, c.dx10.a4.occ, 
+   c.dx10.a4.housng, c.dx10.a4.eco, c.dx10.a4.health, c.dx10.a4.legal, c.dx10.a4.psyenv, c.dx10.a4.none, c.dx10.a5.gaf, c.dx10.curr.abl, 
+   c.dx10.pot.abl,c.dx10.iq.score,c.dx10.iq.date,c.dx10.iq.test,c.dx10.sq.score,c.dx10.sq.date,c.dx10.sq.test, c.dx10.snapid, c.dx10.converted)
+
+   endif  			'End of ER001 block 
 
   else
    SaveData = 0
@@ -1772,7 +1832,7 @@ function PromptPullFW(PULLFW, ForcePullFw) is x
 
  PromptPullFw = "N"
 
- if ForcePullFw = "Y"
+ if ForcePullFw = "Y" or UIDid dp	'ER001 - add UIDid check, if passed - force the force, and may the force be with you... 
   PromptPullFw = "Y"
   return
  endif

--- a/uScript/DX10His.usc
+++ b/uScript/DX10His.usc
@@ -1,0 +1,419 @@
+'Display Diagnosis History - Taken from usbdxhist2 written by Wendy on 8/1/05
+	'Using a DBSEARCH to select one consumer and display all the          
+	'Dx history entered for this consumer.
+'Author Eric Roberts @ StarCare with contributions from Rob Beckham's original DX10His - 09/29/15
+'Date 10/05/15
+
+'The goal of this program is to display the Participants ENTIRE diagnosis history, including both ICD9 and ICD10 diagnoses, based on the 
+'parmfile passed in.
+
+%allow_nonmapped_io
+
+'-----Internal|State version'
+%version 01.00.001 10/14/15
+
+start DX10His(parmfile,option,client,retcode)
+
+%include c_cldef
+%include c_clget
+%include c_incmaps
+
+$looplimit = 0
+
+$trace("path", "/c1/RAUT/SCRIPT/S/DX10HisTrace")
+
+passoption 				is x	'load the option variable with UID for selected record
+
+DiagsReturned[,]		is x	'array for capturing the display data
+'** check boxes 
+diagview[]				is n
+diagvoid[]				is x
+diagupdate[]			is x
+
+color 		            is i    			 
+action					is x
+vcnt					is n
+rc2						is n
+dx10done				is x
+step					is i
+s.fn                	is x                	
+s.ln					is x
+s.profile				is x
+staffname               is x
+uid						is x
+canvoid[]				is x	'array list of Group codes that can void
+canupdate[]				is x	'array list of Group codes that can update
+canDE[]					is x	'array list of Group codes that can do Data Entry in DX10
+canPRM[]				is x	'array list of Group codes that can do Clinician in DX10
+canSeeVoid[]			is x	'array list of Group codes that can see voided diagnoses
+Icanvoid				is x    'can this user void?
+Icanupdate				is x	'can this user update?
+IcanDE					is x	'can this user use DX10DE parmfile?
+IcanPRM					is x	'can this user use DX10PRM parmfile?
+IcanSee					is x	'can this user see voids?
+whocanvoid				is x	'parm passed in from parmfile
+whocanupdate			is x	'parm passed in from parmfile
+whocanDE				is x	'parm passed in from parmfile
+whocanPRM				is x	'parm passed in from parmfile
+seethevoid   			is x	'parm passed in from parmfile
+
+lib-dx					is b
+optionsave				is x 	'save incoming option variable
+didanything				is x    'Did the user just View or actually make a change?
+
+groupmembership[]   	is x
+groupaccess[]       	is x
+
+if parmfile !dp			'Just in case default
+parmfile = "DX10HIS"
+endif
+
+rc = $loadlib(lib-dx, "lib_DX10")
+
+optionsave = option 		'We will reset the variable when we're done calling the detail displays
+
+getparm(parmfile)
+getoption(option)
+
+'$trace("ON")
+
+(void)$getopergroups($oper, groupmembership[], groupaccess[])
+
+Icanvoid = "N"		'start with No You Cant
+if whocanvoid dp
+	$parsem(whocanvoid,1,"|",canvoid[])
+	step = 0
+		do while ++step <= $maxarray(groupmembership[]) and Icanvoid = "N"
+			'Can the User void a diagnosis
+			rc = $find(groupmembership[step], canvoid[], 1, "F")
+            if rc > 0
+				Icanvoid = "Y"		'if Group code is in array, set to Yes
+			endif
+		enddo
+endif
+
+Icanupdate = "N"	'start with No You Cant update at all
+IcanPRM = "N"		'start with No You Cant do PRM mode
+IcanDE = "N"		'start with No You Cant do DE mode
+if whocanupdate dp
+	$parsem(whocanupdate,1,"|",canupdate[])
+	step = 0
+		do while ++step <= $maxarray(groupmembership[]) and Icanupdate = "N"
+			'Can the User do updates to a diagnosis?
+			rc = $find(groupmembership[step], canupdate[], 1, "F")
+            if rc > 0
+				Icanupdate = "Y"	'if Group code is in array, set to Yes - then see if they can PRM or DE
+				'if the User can do updates - can they use Data Entry mode or PRM mode?
+				if whocanPRM dp		'check for PRM mode first
+					$parsem(whocanPRM,1,"|",canPRM[])
+					step = 0
+						do while ++step <= $maxarray(groupmembership[]) and IcanPRM = "N"
+							rc = $find(groupmembership[step], canupdate[], 1, "F")
+            				if rc > 0
+								IcanPRM = "Y"	'if Group code is in array, set to Yes
+							endif
+						enddo
+				endif	'whocanPRM dp
+				if IcanPRM = "N" and whocanDE dp	'they cant PRM and we do have DE entries to check against
+					$parsem(whocanDE,1,"|",canDE[])
+					step = 0
+						do while ++step <= $maxarray(groupmembership[]) and IcanDE = "N"
+							rc = $find(groupmembership[step], canDE[], 1, "F")
+            				if rc > 0
+								IcanDE = "Y"	'if Group code is in array, set to Yes
+							endif
+						enddo
+				endif	'IcanPRM = "N" and whocanDE dp
+			endif	'rc > 0 for $find(groupmembership[step], canupdate[], 1, "F")
+		enddo	'++step <= $maxarray(groupmembership[]) and Icanupdate = "N"
+endif	'whocanupdate dp
+
+IcanSee = "N"		'start with No You Cant see voids
+if seethevoid dp
+	$parsem(seethevoid,1,"|",canSeeVoid[])
+	step = 0
+		do while ++step <= $maxarray(groupmembership[]) and IcanSee = "N"
+			'Can the User see a voided diagnosis
+			rc = $find(groupmembership[step], canSeeVoid[], 1, "F")
+            if rc > 0
+				IcanSee = "Y"		'if Group code is in array, set to Yes
+			endif
+		enddo
+endif
+'******************************************SET FONT STYLES**********************
+$setstyle(".pb", "page-break-before:always;")
+$setstyle(".a8", "font-family:arial", "font-size:8pt", "color:black")
+$setstyle(".a9rb", "font-family:arial", "font-size:9pt", "color:red","font-weight:bold")
+$setstyle(".a9b", "font-family:arial", "font-size:9pt", "color:blue")
+$setstyle(".a9bb", "font-family:arial", "font-size:9pt", "color:blue","font-weight:bold")
+$setstyle(".a9bbu", "font-family:arial", "font-size:9pt", "color:blue","font-weight:bold", "font-style:underline")
+$setstyle(".a10", "font-family:arial", "font-size:10pt", "color:black")
+$setstyle(".a10b", "font-family:arial", "font-size:10pt", "color:black","font-weight:bold")
+$setstyle(".a11", "font-family:arial", "font-size:11pt", "color: whitesmoke")
+$setstyle(".a11b", "font-family:arial", "font-size:11pt", "color: #FA665D")
+
+'BEGIN PROCESSING
+Begin:	'Come back here if anything changed
+step = 0
+color = 0  
+
+$clear(DiagsReturned[,],diagview[],diagvoid[],diagupdate[])
+
+' UPDATE CLIENT DATE FOR PORTAL - Daniel L. Smith
+if client !dp
+	client = $regid
+else
+	$regid = client
+endif
+
+didanything = "N"	'Set flag before loading arrays
+
+lib-dx:DXGet(parmfile,option,$regid,DiagsReturned[,])	'go get diagnoses
+					
+					'DiagsReturned[row,1] = Who Diagnosed it 
+					'DiagsReturned[row,2] = Who Entered it
+					'DiagsReturned[row,3] = ICD 9 or 10
+					'DiagsReturned[row,4] = Diagnosis date
+					'DiagsReturned[row,5] = Diagnosis code
+					'DiagsReturned[row,6] = Diagnosis description
+					'DiagsReturned[row,7] = ICD10-Category/ICD9-Action
+					'DiagsReturned[row,8] = Axis
+					'DiagsReturned[row,9] = GAF
+					'DiagsReturned[row,10] = Primary Axis
+					'DiagsReturned[row,11] = "Y" or "N"		yes is first diagnosis from ICD record
+					'DiagsReturned[row,12] = UID for record
+					'DiagsReturned[row,13] = status
+
+Redisplay:	'Come back here if only View mode was selected
+
+$submitopt("off","Process Selections")
+$cancelopt("off", "Done")
+
+$form("f2")
+$setformtimeout(60)
+%include c_clformheader 
+'TITLE INFO
+$tag("<CENTER>")
+$style("datatag")
+$text("Diagnosis History","H1")
+$tag("</CENTER>")
+$br(2)
+
+$table("t2", ,"border='1' width='100%'")
+
+$row(, "align='center'")
+
+    $col("center","center",,,,"bgcolor='#223E7f'") $text("View","a11")
+	if Icanvoid = "Y" 	
+		$col("center","center",,,,"bgcolor='#223E7f'") $text("VOID","a11b") 	
+	endif
+	if Icanupdate = "Y"	
+		$col("center","center",,,,"bgcolor='#223E7f'") $text("Update","a11b") 	
+	endif
+	$col("center","center",,,,"bgcolor='#223E7f'") $text("Dx Date","a11")
+	$col("center","center",,,,"bgcolor='#223E7f'") $text("Dx Cat.","a11")
+	$col("center","center",,,,"bgcolor='#223E7f'") $text("Diagnosis","a11")
+	$col("center","center",,,,"bgcolor='#223E7f'") $text("Desc.","a11")
+	$col("center","center",,,,"bgcolor='#223E7f'") $text("Legacy Axis","a11")
+	$col("center","center",,,,"bgcolor='#223E7f'") $text("ICD","a11")
+	$col("center","center",,,,"bgcolor='#223E7f'") $text("Cur. GAF","a11")
+	$col("center","center",,,,"bgcolor='#223E7f'") $text("SRC Dx STAFF","a11")
+
+step = 0
+
+do while ++step <= $maxarray(DiagsReturned[,])	
+
+    If color = 0 then
+       color = 1
+    else
+       color = 0
+    endif
+
+    if color = 0 then
+	    $row(, "align='center' bgcolor='#ffffff'")
+    else
+   		$row(, "align='center' bgcolor='#eeeeee'")
+    endif      
+
+	if (IcanSee = "Y" and DiagsReturned[step,13] = "V") or DiagsReturned[step,13] <> "V"		'Only certain people can see voids
+	                                              
+	$col("center")	'Load view checkbox 
+		if DiagsReturned[step,11] = "Y"		'Display first entry of each record	
+			diagview[step] = DiagsReturned[step,4]	'this leaves the checkbox unchecked	
+			$checkbox(diagview[step],,DiagsReturned[step,4])
+		endif
+
+	if DiagsReturned[step,11] = "Y"	and DiagsReturned[step,3] = "10" and DiagsReturned[step,13] <> "V"	'Display first entry of each record	
+		if Icanvoid = "Y"
+			$col("center")
+			$checkbox(diagvoid[step],,DiagsReturned[step,11])	'If user can void
+		endif
+		if Icanupdate = "Y"
+			$col("center")
+			$checkbox(diagupdate[step],,DiagsReturned[step,11])	'If user can update
+		endif
+	else
+		if Icanvoid = "Y"
+			$col("center")
+				if DiagsReturned[step,11] = "Y"	and DiagsReturned[step,13] = "V"
+					$text("Void","a11b")
+				endif
+		endif
+		if Icanupdate = "Y"
+			$col("center")
+		endif
+	endif
+			
+	$col("center")	'Diagnosis date
+		if DiagsReturned[step,11] = "Y"		'Display first entry of each record	
+			if DiagsReturned[step,3] = "10"
+				$text(DiagsReturned[step,4],"a9rb")
+			else
+				$text(DiagsReturned[step,4],"a9bb")
+			endif
+		endif
+
+	$col("center")	'Primary axis
+		'if dxstaf[step] dp
+		if DiagsReturned[step,3] = "10"
+			$text(DiagsReturned[step,7],"a9rb")
+		else
+			$text(DiagsReturned[step,7],"a9bb")
+		endif
+		'endif		
+
+	$col("center")	'Diagnosis code
+		if DiagsReturned[step,3] = "10"
+			$text(DiagsReturned[step,5],"a9rb")
+		else
+			$text(DiagsReturned[step,5],"a9bb")
+		endif
+
+	$col("center")	'Diagnosis description
+		if DiagsReturned[step,3] = "10"
+			$text(DiagsReturned[step,6],"a9rb")
+		else
+			$text(DiagsReturned[step,6],"a9bb")
+		endif
+
+	$col("center")	'Legacy axis
+		if DiagsReturned[step,3] = "10"
+			$text(DiagsReturned[step,8],"a9rb")
+		else
+			$text(DiagsReturned[step,8],"a9bb")
+		endif
+
+	$col("center")	'ICD Level
+		if DiagsReturned[step,3] = "10"
+			$text(DiagsReturned[step,3],"a9rb")
+		else
+			$text(DiagsReturned[step,3],"a9bb")
+		endif
+
+	$col("center")	'GAF score
+		if DiagsReturned[step,11] = "Y"		'Display first entry of each record	
+			if DiagsReturned[step,3] = "10"
+				$text(DiagsReturned[step,9],"a9rb")
+			else
+				$text(DiagsReturned[step,9],"a9bb")
+			endif
+		endif
+
+	$col("center")	'Diagnosed by
+		if DiagsReturned[step,11] = "Y"		'Display first entry of each record	
+			rc = $dbread(03,DiagsReturned[step,1],s.ln,s.fn)
+			staffname = DiagsReturned[step,2] +  " " + s.fn + " " + s.ln
+			if DiagsReturned[step,3] = "10"
+				$text(staffname,"a9rb")
+			else
+				$text(staffname,"a9bb")
+			endif
+		endif
+
+	endif		'(IcanSee = "Y" and DiagsReturned[step,13] = "V") or DiagsReturned[step,13] <> "V"
+
+enddo
+
+$endtable("t2")
+
+%include c_pbutton
+$sendform("f2")
+$endform("f2")
+
+if $endbutton = "TIME"
+	goto Begin
+elseif $endbutton = "SUBMIT" then
+	gosub ProcessCheckBoxes		'Process selected diagnosis based on which box is checked
+	if didanything = "Y" 	'We voided or updated, so we will need to reload
+		goto Begin
+	else                    'Otherwise we can just redisplay what we have
+		goto Redisplay
+	endif
+elseif $endbutton = "CANCEL"
+	goto TheEnd
+endif
+
+ProcessCheckBoxes:
+
+$clear(vcnt)
+
+do while ++vcnt <= $maxarray(DiagsReturned[,])
+
+	if diagview[vcnt] dp		'View box checked
+
+		passoption = option + "UIDpassed`" + DiagsReturned[vcnt,12] + ";"	'Set option variable to include UID	
+		option = passoption
+
+		if DiagsReturned[vcnt,3] = "9" 		'ICD9 
+
+			call "DX09" ("DX10HIS",option,$regid,DiagsReturned[vcnt,12])	
+
+			if DiagsReturned[vcnt,12] = 9.999999	
+			goto TheEnd
+			endif
+
+		else	'diagicd[vcnt] <> "9"
+
+		'DX10 Display
+ 
+			call "DX10" ("DX10VO",option,$regid,retcode)	
+
+		endif	'diagicd[vcnt] = "9"
+		
+		option = optionsave		'reset option variable to original content
+		
+	elseif diagvoid[vcnt] dp		'Void box checked
+	
+		didanything = "Y"	'Since we did something, we will need to reload the array
+	
+		lib-dx:voidClientDx($regid,DiagsReturned[vcnt,12],$today)
+		
+	elseif diagupdate[vcnt] dp		'Update box checked 
+	
+		didanything = "Y"	'Since we did something, we will need to reload the array
+	
+		passoption = option + "UIDpassed`" + DiagsReturned[vcnt,12] + ";"	'Set option variable to include UID	
+		option = passoption
+		
+		if IcanPRM = "Y"
+			call "DX10" ("DX10PRM",option,$regid,retcode)	
+		elseif IcanDE = "Y"
+			call "DX10" ("DX10DE",option,$regid,retcode)
+		endif
+		
+		option = optionsave		'reset option variable to original content
+		
+	endif	'diagview[vcnt] dp
+
+enddo	'vcnt <= $maxarray(dxdate[])
+
+goback
+
+TheEnd:
+end DX10His
+
+%include c_func-lib
+%include inc_GetParm
+%include inc_GetOption
+
+


### PR DESCRIPTION
'ER001  - Eric Roberts 10/20/2015 - allow passing of UID in option file
"UIDpassed`UID#"
'       - this allows the retrieval the appropriate ICD10 diagnosis record,
based on UID passed
'       - for parmfile DX10VO, this allows a user to select the appropriate
record for display in DX10His
'       - for parmfiles DX10DE and DX10PRM this allows a user to select the
appropriate record for update in DX10His
'       - if UID option is not passed, the default is most recent diagnosis
'       - 10/28/2015, and we are cooing with gas!  Changing the SaveData
function to use the updateClientDx and putClientDx functions coded
'       - in lib_DX10.  Also need to bypass certain edits if UID is passed in
